### PR TITLE
chore: update action versions in workflow file

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,6 +1,7 @@
 name: 'Build LaTeX Document'
 on:
   push:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,15 +13,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
-        name: Tectonic Cache
+      - name: Tectonic Cache
+        uses: actions/cache@v3
         with:
           path: ~/.cache/Tectonic
           key: ${{ runner.os }}-tectonic-${{ hashFiles('**/*.tex') }}
           restore-keys: |
             ${{ runner.os }}-tectonic-
 
-      - uses: wtfjoke/setup-tectonic@v1
+      - name: Setup Tectonic
+        uses: wtfjoke/setup-tectonic@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -24,7 +24,7 @@ jobs:
         run: tectonic main.tex
 
       - name: Upload pdf
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: main
           path: main.pdf

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - uses: actions/cache@v3
         name: Tectonic Cache
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tectonic-
 
-      - uses: wtfjoke/setup-tectonic@v3
+      - uses: wtfjoke/setup-tectonic@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -28,7 +28,7 @@ jobs:
         run: tectonic main.tex
 
       - name: Upload PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: main
           path: main.pdf

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,45 +6,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install FUSE
-        run: sudo apt-get install -y fuse
-
-      - name: Tectonic Cache
-        uses: actions/cache@v3
+      - uses: actions/cache@v3
+        name: Tectonic Cache
         with:
           path: ~/.cache/Tectonic
           key: ${{ runner.os }}-tectonic-${{ hashFiles('**/*.tex') }}
           restore-keys: |
             ${{ runner.os }}-tectonic-
 
-      - name: Setup Tectonic
-        uses: wtfjoke/setup-tectonic@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: wtfjoke/setup-tectonic@v3
 
       - name: Run Tectonic
         run: tectonic main.tex
 
-      - name: Upload PDF
-        uses: actions/upload-artifact@v4
+      - name: Upload pdf
+        uses: actions/upload-artifact@v3
         with:
           name: main
           path: main.pdf
-
-      - name: Commit and Push PDF
-        run: |
-          mv main.pdf resume.pdf
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add resume.pdf
-          git commit -m 'build: Update generated PDF'
-          git push origin main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install FUSE
+        run: sudo apt-get install -y fuse
+
       - name: Tectonic Cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Update the versions of actions used in the GitHub workflow. 
Change `actions/checkout` from v4 to v3, `actions/upload-artifact` 
from v3 to v4, and `wtfjoke/setup-tectonic` from v3 to v1. This 
ensures compatibility and stability with the latest features and 
fixes provided by the respective actions.